### PR TITLE
mark .github as documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+.github/* linguist-documentation


### PR DESCRIPTION
- [x] I promise I have read the [contribution guidelines](https://github.com/mxstbr/awesome-austria/blob/master/contributing.md) twice and ensured my submission follows it.

Because the markdown file only includes comments, it was recognised as GCM. This will make the language stats ignore that folder.
